### PR TITLE
refactor core options

### DIFF
--- a/src/burner/libretro/libretro.cpp
+++ b/src/burner/libretro/libretro.cpp
@@ -728,25 +728,6 @@ void retro_get_system_av_info(struct retro_system_av_info *info)
    if (log_cb)
       log_cb(RETRO_LOG_INFO, "retro_get_system_av_info: base_width: %d, base_height: %d, max_width: %d, max_height: %d, aspect_ratio: %f\n", geom.base_width, geom.base_height, geom.max_width, geom.max_height, geom.aspect_ratio);
 
-   info->geometry = geom;
-}
-
-void retro_get_system_av_info(struct retro_system_av_info *info)
-{
-   int width, height;
-   BurnDrvGetVisibleSize(&width, &height);
-   int maximum = width > height ? width : height;
-   struct retro_game_geometry geom = { (unsigned)width, (unsigned)height, (unsigned)maximum, (unsigned)maximum };
-
-   int game_aspect_x, game_aspect_y;
-   BurnDrvGetAspect(&game_aspect_x, &game_aspect_y);
-
-   if (game_aspect_x != 0 && game_aspect_y != 0 && !core_aspect_par)
-      geom.aspect_ratio = (float)game_aspect_x / (float)game_aspect_y;
-
-   if (log_cb)
-      log_cb(RETRO_LOG_INFO, "retro_get_system_av_info: base_width: %d, base_height: %d, max_width: %d, max_height: %d, aspect_ratio: %f\n", geom.base_width, geom.base_height, geom.max_width, geom.max_height, geom.aspect_ratio);
-
 #ifdef FBACORES_CPS
    struct retro_system_timing timing = { 59.629403, 59.629403 * AUDIO_SEGMENT_LENGTH };
 #else

--- a/src/burner/libretro/libretro.cpp
+++ b/src/burner/libretro/libretro.cpp
@@ -41,6 +41,7 @@ static unsigned int BurnDrvGetIndexByName(const char* name);
 static neo_geo_modes g_opt_neo_geo_mode = NEO_GEO_MODE_MVS;
 static bool gamepad_controls = true;
 static bool newgen_controls = false;
+static bool core_aspect_par = false;
 
 #define STAT_NOFIND  0
 #define STAT_OK      1
@@ -80,6 +81,7 @@ void retro_set_input_poll(retro_input_poll_t cb) { poll_cb = cb; }
 void retro_set_input_state(retro_input_state_t cb) { input_cb = cb; }
 
 static const struct retro_variable vars_generic[] = {
+   { "fba-aspect", "Core Provided Aspect Ratio; PAR|DAR" },
    { "fba-cpu-speed-adjust", "CPU Speed Overclock; 100|110|120|130|140|150|160|170|180|190|200" },
    { "fba-controls", "Controls; gamepad|arcade" },
    { "fba-neogeo-mode", "Neo Geo Mode; mvs|aes|unibios" },
@@ -588,6 +590,15 @@ static void check_variables(void)
       else
          newgen_controls = false;
    }
+
+      var.key = "fba-aspect";
+      if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var))
+      {
+         if (strcmp(var.value, "PAR") == 0)
+            core_aspect_par = true;
+         else
+            core_aspect_par = false;
+      }
 }
 
 void retro_run()
@@ -705,7 +716,7 @@ void retro_get_system_av_info(struct retro_system_av_info *info)
    int game_aspect_x, game_aspect_y;
    BurnDrvGetAspect(&game_aspect_x, &game_aspect_y);
 
-   if (game_aspect_x != 0 && game_aspect_y != 0)
+   if (game_aspect_x != 0 && game_aspect_y != 0 && !core_aspect_par)
       geom.aspect_ratio = (float)game_aspect_x / (float)game_aspect_y;
 
    if (log_cb)

--- a/src/burner/libretro/libretro.cpp
+++ b/src/burner/libretro/libretro.cpp
@@ -641,7 +641,13 @@ void retro_run()
    if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE_UPDATE, &updated) && updated)
    {
       check_variables();
+      // todo: only reinit when needed
       init_input();
+
+      // todo: only reinit when needed
+      struct retro_system_av_info av_info;
+      retro_get_system_av_info(&av_info);
+      environ_cb(RETRO_ENVIRONMENT_SET_GEOMETRY, &av_info);
    }
 }
 
@@ -705,6 +711,25 @@ bool retro_unserialize(const void *data, size_t size)
 
 void retro_cheat_reset() {}
 void retro_cheat_set(unsigned, bool, const char*) {}
+
+void retro_get_system_av_info(struct retro_system_av_info *info)
+{
+   int width, height;
+   BurnDrvGetVisibleSize(&width, &height);
+   int maximum = width > height ? width : height;
+   struct retro_game_geometry geom = { (unsigned)width, (unsigned)height, (unsigned)maximum, (unsigned)maximum };
+
+   int game_aspect_x, game_aspect_y;
+   BurnDrvGetAspect(&game_aspect_x, &game_aspect_y);
+
+   if (game_aspect_x != 0 && game_aspect_y != 0 && !core_aspect_par)
+      geom.aspect_ratio = (float)game_aspect_x / (float)game_aspect_y;
+
+   if (log_cb)
+      log_cb(RETRO_LOG_INFO, "retro_get_system_av_info: base_width: %d, base_height: %d, max_width: %d, max_height: %d, aspect_ratio: %f\n", geom.base_width, geom.base_height, geom.max_width, geom.max_height, geom.aspect_ratio);
+
+   info->geometry = geom;
+}
 
 void retro_get_system_av_info(struct retro_system_av_info *info)
 {

--- a/src/burner/libretro/libretro.cpp
+++ b/src/burner/libretro/libretro.cpp
@@ -81,11 +81,11 @@ void retro_set_input_poll(retro_input_poll_t cb) { poll_cb = cb; }
 void retro_set_input_state(retro_input_state_t cb) { input_cb = cb; }
 
 static const struct retro_variable vars_generic[] = {
-   { "fba-aspect", "Core Provided Aspect Ratio; PAR|DAR" },
-   { "fba-cpu-speed-adjust", "CPU Speed Overclock; 100|110|120|130|140|150|160|170|180|190|200" },
-   { "fba-controls", "Controls; gamepad|arcade" },
-   { "fba-neogeo-mode", "Neo Geo Mode; mvs|aes|unibios" },
-   { "fba-neogeo-controls", "Neo Geo Gamepad Layout; classic|newgen" },
+   { "fba-aspect", "Core-provided aspect ratio; DAR|PAR" },
+   { "fba-cpu-speed-adjust", "CPU overclock; 100|110|120|130|140|150|160|170|180|190|200" },
+   { "fba-controls", "Control scheme; gamepad|arcade" },
+   { "fba-neogeo-mode", "Neo Geo mode; mvs|aes|unibios" },
+   { "fba-neogeo-controls", "Neo Geo gamepad scheme; classic|newgen" },
    { NULL, NULL },
 };
 


### PR DESCRIPTION
- split the control core options in a generic one and one for neogeo gamepad
- make input related core options apply immeaditely
- remove some code duplication in open_archive (just use check_variables instead)
- make the core options more straightforward and "safer"
- add an option so that core provided AR is either PAR or DAR,