### PR TITLE
Add DIP Switches in core options depending on the game (drv)

### DIFF
--- a/src/burn/drv/cps3/cps3run.cpp
+++ b/src/burn/drv/cps3/cps3run.cpp
@@ -1049,14 +1049,20 @@ static INT32 Cps3Reset()
 			Sh2SetVBR(0x06000000);
 		}
 	}
-	
-	if (cps3_dip & 0x80) {
-		EEPROM[0x11] = 0x100 + (EEPROM[0x11] & 0xff);
-		EEPROM[0x29] = 0x100 + (EEPROM[0x29] & 0xff);
-	} else {
-		EEPROM[0x11] = 0x000 + (EEPROM[0x11] & 0xff);
-		EEPROM[0x29] = 0x000 + (EEPROM[0x29] & 0xff);
-	}
+
+   // Patch the EEPROM is not needed for sfiii2 and cause some issues if it's done on it.
+   // Normally this is only needed for sfiii but I have nothing to know what the current game is
+   // without adding a new property in the driver
+	if (!cps3_isSpecial)
+	{
+		if (cps3_dip & 0x80) {
+			EEPROM[0x11] = 0x100 + (EEPROM[0x11] & 0xff);
+			EEPROM[0x29] = 0x100 + (EEPROM[0x29] & 0xff);
+		} else {
+			EEPROM[0x11] = 0x000 + (EEPROM[0x11] & 0xff);
+			EEPROM[0x29] = 0x000 + (EEPROM[0x29] & 0xff);
+		}
+   }
 
 	cps3_current_eeprom_read = 0;	
 	cps3SndReset();	

--- a/src/burner/libretro/libretro.cpp
+++ b/src/burner/libretro/libretro.cpp
@@ -39,6 +39,9 @@ enum neo_geo_modes
 
    /* UNIBIOS */
    NEO_GEO_MODE_UNIBIOS = 2,
+
+   /* DIPSWITCH */
+   NEO_GEO_MODE_DIPSWITCH = 3,
 };
 
 static unsigned int BurnDrvGetIndexByName(const char* name);
@@ -93,7 +96,7 @@ static const struct retro_variable var_fba_cpu_speed_adjust = { "fba-cpu-speed-a
 static const struct retro_variable var_fba_controls = { "fba-controls", "Control scheme; gamepad|arcade" };
 
 // Neo Geo core options
-static const struct retro_variable var_neogeo_mode = { "fba-neogeo-mode", "Neo Geo mode; mvs|aes|unibios" };
+static const struct retro_variable var_neogeo_mode = { "fba-neogeo-mode", "Neo Geo mode; MVS|AES|UNIBIOS|DIPSWITCH" };
 static const struct retro_variable var_neogeo_controls = { "fba-neogeo-controls", "Neo Geo gamepad scheme; classic|newgen" };
 
 void retro_set_environment(retro_environment_t cb)
@@ -159,10 +162,14 @@ static RomBiosInfo *available_uni_bios = NULL;
 
 void set_neo_system_bios()
 {
-   NeoSystem &= ~0x1f;
-
-   if (g_opt_neo_geo_mode == NEO_GEO_MODE_MVS)
+   if (g_opt_neo_geo_mode == NEO_GEO_MODE_DIPSWITCH)
    {
+      // Nothing to do in DIPSWITCH mode because the NeoSystem variable is changed by the DIP Switch core option
+      log_cb(RETRO_LOG_INFO, "DIPSWITCH Neo Geo Mode selected => NeoSystem: 0x%02x.\n", NeoSystem);
+   }
+   else if (g_opt_neo_geo_mode == NEO_GEO_MODE_MVS)
+   {
+      NeoSystem &= ~0x1f;
       if (available_mvs_bios)
       {
          NeoSystem |= available_mvs_bios->NeoSystem;
@@ -181,6 +188,7 @@ void set_neo_system_bios()
    }
    else if (g_opt_neo_geo_mode == NEO_GEO_MODE_AES)
    {
+      NeoSystem &= ~0x1f;
       if (available_aes_bios)
       {
          NeoSystem |= available_aes_bios->NeoSystem;
@@ -199,6 +207,7 @@ void set_neo_system_bios()
    }
    else if (g_opt_neo_geo_mode == NEO_GEO_MODE_UNIBIOS)
    {
+      NeoSystem &= ~0x1f;
       if (available_uni_bios)
       {
          NeoSystem |= available_uni_bios->NeoSystem;
@@ -955,12 +964,14 @@ static void check_variables(void)
       var.key = var_neogeo_mode.key;
       if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var))
       {
-         if (strcmp(var.value, "mvs") == 0)
+         if (strcmp(var.value, "MVS") == 0)
             g_opt_neo_geo_mode = NEO_GEO_MODE_MVS;
-         else if (strcmp(var.value, "aes") == 0)
+         else if (strcmp(var.value, "AES") == 0)
             g_opt_neo_geo_mode = NEO_GEO_MODE_AES;
-         else if (strcmp(var.value, "unibios") == 0)
+         else if (strcmp(var.value, "UNIBIOS") == 0)
             g_opt_neo_geo_mode = NEO_GEO_MODE_UNIBIOS;
+         else if (strcmp(var.value, "DIPSWITCH") == 0)
+            g_opt_neo_geo_mode = NEO_GEO_MODE_DIPSWITCH;
       }
    }
 }


### PR DESCRIPTION
Small 'non exhaustive' list of imrovements thanks the DIP Switch:
- Configuration in CPS1 and other Systems
- Region selection in CPS3 (Also thanks the reorder of the init_input method call)
- Fake WideScreen Option for SFIII
- Fix the Widescreen Option in SFIII2 on starup (cps3run.cpp)
- Region (NTSC/PAL) selection for Megadrive and maybe other consoles. This makes protected games working.
- Add a new NeoGeo mode value to select the Bios from the DipSwitch option.
- Change NeoGeo mode value case setting into CamelCase to be more user friendly.
  So the core-options.cfg file must be re-evaluated.
