### PR TITLE
Fix the bprint log method

### DIFF
--- a/src/burn/burn.cpp
+++ b/src/burn/burn.cpp
@@ -5,11 +5,13 @@
 #include "burn_sound.h"
 #include "driverlist.h"
 
+#ifndef __LIBRETRO__
 // filler function, used if the application is not printing debug messages
 static INT32 __cdecl BurnbprintfFiller(INT32, TCHAR* , ...) { return 0; }
 // pointer to burner printing function
 #ifndef bprintf
 INT32 (__cdecl *bprintf)(INT32 nStatus, TCHAR* szFormat, ...) = BurnbprintfFiller;
+#endif
 #endif
 
 INT32 nBurnVer = BURN_VERSION;		// Version number of the library

--- a/src/burner/libretro/libretro.cpp
+++ b/src/burner/libretro/libretro.cpp
@@ -33,6 +33,33 @@ static retro_input_poll_t poll_cb;
 static retro_input_state_t input_cb;
 static retro_audio_sample_batch_t audio_batch_cb;
 
+#define BPRINTF_BUFFER_SIZE 512
+char bprintf_buf[BPRINTF_BUFFER_SIZE];
+static INT32 __cdecl libretro_bprintf(INT32 nStatus, TCHAR* szFormat, ...)
+{
+   va_list vp;
+   va_start(vp, szFormat);
+   int rc = vsnprintf(bprintf_buf, BPRINTF_BUFFER_SIZE, szFormat, vp);
+   va_end(vp);
+
+   if (rc >= 0)
+   {
+      retro_log_level retro_log = RETRO_LOG_DEBUG;
+      if (nStatus == PRINT_UI)
+         retro_log = RETRO_LOG_INFO;
+      else if (nStatus == PRINT_IMPORTANT)
+         retro_log = RETRO_LOG_WARN;
+      else if (nStatus == PRINT_ERROR)
+         retro_log = RETRO_LOG_ERROR;
+         
+      log_cb(retro_log, bprintf_buf);
+   }
+   
+   return rc;
+}
+
+INT32 (__cdecl *bprintf) (INT32 nStatus, TCHAR* szFormat, ...) = libretro_bprintf;
+
 // FBARL ---
 
 extern UINT8 NeoSystem;

--- a/src/burner/libretro/tchar.h
+++ b/src/burner/libretro/tchar.h
@@ -34,8 +34,6 @@
 typedef struct { int x, y, width, height; } RECT;
 #undef __cdecl
 #define __cdecl
-
-#define bprintf(...) {}
 #endif
 
 #undef __fastcall


### PR DESCRIPTION
We must take care next we will sync from the Official FBA to not discard
the changes from tchar.h and burn.cpp
Rem: All the project has to be recompiled to see the changes.

This fix the issue related here http://libretro.com/forums/showthread.php?t=4008 by @barbudreadmon.