### PR TITLE
fix loading without fullpath courtesy of Alcaro

### DIFF
--- a/src/burner/libretro/libretro.cpp
+++ b/src/burner/libretro/libretro.cpp
@@ -1425,7 +1425,10 @@ static void extract_directory(char *buf, const char *path, size_t size)
    if (base)
       *base = '\0';
    else
-      buf[0] = '\0';
+    {
+      buf[0] = '.';
+      buf[1] = '\0';
+    }
 }
 
 bool retro_load_game(const struct retro_game_info *info)
@@ -2412,12 +2415,12 @@ static void init_macro_core_options()
       macro_core_options.push_back(macro_core_option());
       macro_core_option *macro_option = &macro_core_options.back();
 
-      // Clean the macro name to creation the core option name (removing space, equal characters and the special '×' from 3× Punch/Kick)
+      // Clean the macro name to creation the core option name (removing space, equal characters and the special 'Ã—' from 3Ã— Punch/Kick)
       char option_name[strlen(pgi->Macro.szName) + 1]; // + 1 for the '\0' ending
       strcpy(option_name, pgi->Macro.szName);
       str_char_replace(option_name, ' ', '_');
       str_char_replace(option_name, '=', '_');
-      str_char_replace(option_name, '×', 'x'); // Remove the strange '×' from '3× Punch' and '3× Kick' (core options are buggy with it)
+      str_char_replace(option_name, 'Ã—', 'x'); // Remove the strange 'Ã—' from '3Ã— Punch' and '3Ã— Kick' (core options are buggy with it)
 
       macro_option->pgi = pgi;
       strncpy(macro_option->friendly_name, pgi->Macro.szName, sizeof(macro_option->friendly_name));


### PR DESCRIPTION
closes issue #67. Looks like the github web editor changed two comments to UTF-8 automatically...